### PR TITLE
Add heap max ratio and force trigger

### DIFF
--- a/java-oom/src/main/java/com/kwai/koom/javaoom/common/KConfig.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/common/KConfig.java
@@ -1,10 +1,10 @@
 package com.kwai.koom.javaoom.common;
 
-import static com.kwai.koom.javaoom.common.KGlobalConfig.KOOM_DIR;
+import com.kwai.koom.javaoom.monitor.HeapThreshold;
 
 import java.io.File;
 
-import com.kwai.koom.javaoom.monitor.HeapThreshold;
+import static com.kwai.koom.javaoom.common.KGlobalConfig.KOOM_DIR;
 
 /**
  * Copyright 2020 Kwai, Inc. All rights reserved.
@@ -59,6 +59,7 @@ public class KConfig {
   public static class KConfigBuilder {
 
     private float heapRatio;
+    private float heapMaxRatio;
     private int heapOverTimes;
     private int heapPollInterval;
 
@@ -68,6 +69,7 @@ public class KConfig {
 
     public KConfigBuilder() {
       this.heapRatio = KConstants.HeapThreshold.getDefaultPercentRation();
+      this.heapMaxRatio = KConstants.HeapThreshold.getDefaultMaxPercentRation();
       this.heapOverTimes = KConstants.HeapThreshold.OVER_TIMES;
       this.heapPollInterval = KConstants.HeapThreshold.POLL_INTERVAL;
       File cacheFile = KGlobalConfig.getApplication().getCacheDir();
@@ -82,6 +84,11 @@ public class KConfig {
 
     public KConfigBuilder heapRatio(float heapRatio) {
       this.heapRatio = heapRatio;
+      return this;
+    }
+
+    public KConfigBuilder heapMaxRatio(float heapMaxRatio) {
+      this.heapMaxRatio = heapMaxRatio;
       return this;
     }
 
@@ -101,8 +108,11 @@ public class KConfig {
     }
 
     public KConfig build() {
+      if (heapRatio > heapMaxRatio) {
+        throw new RuntimeException("heapMaxRatio be greater than heapRatio");
+      }
       HeapThreshold heapThreshold = new HeapThreshold(heapRatio,
-          heapOverTimes, heapPollInterval);
+              heapMaxRatio, heapOverTimes, heapPollInterval);
       return new KConfig(heapThreshold, this.rootDir, this.processName);
     }
   }

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/common/KConstants.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/common/KConstants.java
@@ -2,8 +2,6 @@ package com.kwai.koom.javaoom.common;
 
 import static com.kwai.koom.javaoom.common.KConstants.Bytes.MB;
 
-import android.util.Log;
-
 /**
  * Copyright 2020 Kwai, Inc. All rights reserved.
  * <p>
@@ -38,6 +36,8 @@ public class KConstants {
     public static float PERCENT_RATIO_IN_256_DEVICE = 85;
     public static float PERCENT_RATIO_IN_128_DEVICE = 90;
 
+    public static float PERCENT_MAX_RATIO = 95;
+
     public static float getDefaultPercentRation() {
       int maxMem = (int) (Runtime.getRuntime().maxMemory() / MB);
       if (Debug.VERBOSE_LOG) {
@@ -51,6 +51,10 @@ public class KConstants {
         return KConstants.HeapThreshold.PERCENT_RATIO_IN_128_DEVICE;
       }
       return KConstants.HeapThreshold.PERCENT_RATIO_IN_512_DEVICE;
+    }
+
+    public static float getDefaultMaxPercentRation() {
+      return KConstants.HeapThreshold.PERCENT_MAX_RATIO;
     }
 
     public static int OVER_TIMES = 3;

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/FdThreshold.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/FdThreshold.java
@@ -29,6 +29,11 @@ public class FdThreshold implements Threshold {
   }
 
   @Override
+  public float maxValue() {
+    return 0;
+  }
+
+  @Override
   public int overTimes() {
     return DEFAULT_OVER_TIMES;
   }

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapMonitor.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapMonitor.java
@@ -55,25 +55,26 @@ public class HeapMonitor implements Monitor {
 
     HeapStatus heapStatus = currentHeapStatus();
 
+    if (heapStatus.isOverMaxThreshold) {
+      // 已达到最大阀值，强制触发trigger，防止后续出现大内存分配导致OOM进程Crash，无法触发trigger
+      KLog.i(TAG, "heap used is over max ratio, force trigger and over times reset to 0");
+      currentTimes = 0;
+      return true;
+    }
+
     if (heapStatus.isOverThreshold) {
       KLog.i(TAG, "heap status used:" + heapStatus.used / KConstants.Bytes.MB
               + ", max:" + heapStatus.max / KConstants.Bytes.MB
               + ", last over times:" + currentTimes);
-      if (heapStatus.isOverMaxThreshold) {
-        // 已达到最大阀值，强制触发trigger，防止后续出现大内存分配导致OOM进程Crash，无法trigger
-        KLog.i(TAG, "heap used is over max ratio, force trigger and over times reset to 0");
-        currentTimes = 0;
-      } else {
-        if (heapThreshold.ascending()) {
-          if (lastHeapStatus == null || heapStatus.used >= lastHeapStatus.used || heapStatus.isOverMaxThreshold) {
-            currentTimes++;
-          } else {
-            KLog.i(TAG, "heap status used is not ascending, and over times reset to 0");
-            currentTimes = 0;
-          }
-        } else {
+      if (heapThreshold.ascending()) {
+        if (lastHeapStatus == null || heapStatus.used >= lastHeapStatus.used || heapStatus.isOverMaxThreshold) {
           currentTimes++;
+        } else {
+          KLog.i(TAG, "heap status used is not ascending, and over times reset to 0");
+          currentTimes = 0;
         }
+      } else {
+        currentTimes++;
       }
     } else {
       currentTimes = 0;

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapMonitor.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapMonitor.java
@@ -1,7 +1,5 @@
 package com.kwai.koom.javaoom.monitor;
 
-import android.util.Log;
-
 import com.kwai.koom.javaoom.common.KConstants;
 import com.kwai.koom.javaoom.common.KGlobalConfig;
 import com.kwai.koom.javaoom.common.KLog;
@@ -59,24 +57,30 @@ public class HeapMonitor implements Monitor {
 
     if (heapStatus.isOverThreshold) {
       KLog.i(TAG, "heap status used:" + heapStatus.used / KConstants.Bytes.MB
-          + ", max:" + heapStatus.max / KConstants.Bytes.MB
-          + ", last over times:" + currentTimes);
-      if (heapThreshold.ascending()) {
-        if (lastHeapStatus == null || heapStatus.used >= lastHeapStatus.used) {
-          currentTimes++;
-        } else {
-          KLog.i(TAG, "heap status used is not ascending, and over times reset to 0");
-          currentTimes = 0;
-        }
+              + ", max:" + heapStatus.max / KConstants.Bytes.MB
+              + ", last over times:" + currentTimes);
+      if (heapStatus.isOverMaxThreshold) {
+        // 已达到最大阀值，强制触发trigger，防止后续出现大内存分配导致OOM进程Crash，无法trigger
+        KLog.i(TAG, "heap used is over max ratio, force trigger and over times reset to 0");
+        currentTimes = 0;
       } else {
-        currentTimes++;
+        if (heapThreshold.ascending()) {
+          if (lastHeapStatus == null || heapStatus.used >= lastHeapStatus.used || heapStatus.isOverMaxThreshold) {
+            currentTimes++;
+          } else {
+            KLog.i(TAG, "heap status used is not ascending, and over times reset to 0");
+            currentTimes = 0;
+          }
+        } else {
+          currentTimes++;
+        }
       }
     } else {
       currentTimes = 0;
     }
 
     lastHeapStatus = heapStatus;
-    return currentTimes >= heapThreshold.overTimes();
+    return currentTimes >= heapThreshold.overTimes() || heapStatus.isOverMaxThreshold;
   }
 
   private HeapStatus lastHeapStatus;
@@ -86,7 +90,9 @@ public class HeapMonitor implements Monitor {
     heapStatus.max = Runtime.getRuntime().maxMemory();
     heapStatus.used = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
     KLog.i(TAG, 100.0f * heapStatus.used / heapStatus.max + " " + heapThreshold.value());
-    heapStatus.isOverThreshold = 100.0f * heapStatus.used / heapStatus.max > heapThreshold.value();
+    float heapInPercent = 100.0f * heapStatus.used / heapStatus.max;
+    heapStatus.isOverThreshold = heapInPercent > heapThreshold.value();
+    heapStatus.isOverMaxThreshold = heapInPercent > heapThreshold.maxValue();
     return heapStatus;
   }
 
@@ -94,6 +100,7 @@ public class HeapMonitor implements Monitor {
     long max;
     long used;
     boolean isOverThreshold;
+    boolean isOverMaxThreshold;
   }
 
   @Override

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapMonitor.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapMonitor.java
@@ -81,7 +81,7 @@ public class HeapMonitor implements Monitor {
     }
 
     lastHeapStatus = heapStatus;
-    return currentTimes >= heapThreshold.overTimes() || heapStatus.isOverMaxThreshold;
+    return currentTimes >= heapThreshold.overTimes();
   }
 
   private HeapStatus lastHeapStatus;

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapThrashingThreshold.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapThrashingThreshold.java
@@ -31,6 +31,11 @@ public class HeapThrashingThreshold implements Threshold {
   }
 
   @Override
+  public float maxValue() {
+    return 0;
+  }
+
+  @Override
   public int overTimes() {
     return DEFAULT_OVER_TIMES;
   }

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapThreshold.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapThreshold.java
@@ -19,22 +19,22 @@ package com.kwai.koom.javaoom.monitor;
  */
 public class HeapThreshold implements Threshold {
 
-    private float heapRatioInPercent;
-    private float heapMaxRatioInPercent;
-    private int overTimes;
-    private int pollInterval;
+  private float heapRatioInPercent;
+  private float heapMaxRatioInPercent;
+  private int overTimes;
+  private int pollInterval;
 
-    public HeapThreshold(float heapRatioInPercent, float heapMaxRatioInPercent, int overTimes, int pollInterval) {
-        this.heapRatioInPercent = heapRatioInPercent;
-        this.heapMaxRatioInPercent =heapMaxRatioInPercent;
-        this.overTimes = overTimes;
-        this.pollInterval = pollInterval;
-    }
+  public HeapThreshold(float heapRatioInPercent, float heapMaxRatioInPercent, int overTimes, int pollInterval) {
+    this.heapRatioInPercent = heapRatioInPercent;
+    this.heapMaxRatioInPercent = heapMaxRatioInPercent;
+    this.overTimes = overTimes;
+    this.pollInterval = pollInterval;
+  }
 
-    @Override
-    public float value() {
-        return heapRatioInPercent;
-    }
+  @Override
+  public float value() {
+    return heapRatioInPercent;
+  }
 
   @Override
   public float maxValue() {
@@ -42,22 +42,22 @@ public class HeapThreshold implements Threshold {
   }
 
   @Override
-    public int overTimes() {
-        return overTimes;
-    }
+  public int overTimes() {
+    return overTimes;
+  }
 
-    @Override
-    final public ThresholdValueType valueType() {
-        return ThresholdValueType.PERCENT;
-    }
+  @Override
+  final public ThresholdValueType valueType() {
+    return ThresholdValueType.PERCENT;
+  }
 
-    @Override
-    public boolean ascending() {
-        return true;
-    }
+  @Override
+  public boolean ascending() {
+    return true;
+  }
 
-    @Override
-    public int pollInterval() {
-        return pollInterval;
-    }
+  @Override
+  public int pollInterval() {
+    return pollInterval;
+  }
 }

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapThreshold.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/HeapThreshold.java
@@ -19,38 +19,45 @@ package com.kwai.koom.javaoom.monitor;
  */
 public class HeapThreshold implements Threshold {
 
-  private float heapRatioInPercent;
-  private int overTimes;
-  private int pollInterval;
+    private float heapRatioInPercent;
+    private float heapMaxRatioInPercent;
+    private int overTimes;
+    private int pollInterval;
 
-  public HeapThreshold(float heapRatioInPercent, int overTimes, int pollInterval) {
-    this.heapRatioInPercent = heapRatioInPercent;
-    this.overTimes = overTimes;
-    this.pollInterval = pollInterval;
+    public HeapThreshold(float heapRatioInPercent, float heapMaxRatioInPercent, int overTimes, int pollInterval) {
+        this.heapRatioInPercent = heapRatioInPercent;
+        this.heapMaxRatioInPercent =heapMaxRatioInPercent;
+        this.overTimes = overTimes;
+        this.pollInterval = pollInterval;
+    }
+
+    @Override
+    public float value() {
+        return heapRatioInPercent;
+    }
+
+  @Override
+  public float maxValue() {
+    return heapMaxRatioInPercent;
   }
 
   @Override
-  public float value() {
-    return heapRatioInPercent;
-  }
+    public int overTimes() {
+        return overTimes;
+    }
 
-  @Override
-  public int overTimes() {
-    return overTimes;
-  }
+    @Override
+    final public ThresholdValueType valueType() {
+        return ThresholdValueType.PERCENT;
+    }
 
-  @Override
-  final public ThresholdValueType valueType() {
-    return ThresholdValueType.PERCENT;
-  }
+    @Override
+    public boolean ascending() {
+        return true;
+    }
 
-  @Override
-  public boolean ascending() {
-    return true;
-  }
-
-  @Override
-  public int pollInterval() {
-    return pollInterval;
-  }
+    @Override
+    public int pollInterval() {
+        return pollInterval;
+    }
 }

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/ThreadThreshold.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/ThreadThreshold.java
@@ -29,6 +29,11 @@ public class ThreadThreshold implements Threshold {
   }
 
   @Override
+  public float maxValue() {
+    return 0;
+  }
+
+  @Override
   public int overTimes() {
     return DEFAULT_OVER_TIMES;
   }

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/Threshold.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/Threshold.java
@@ -20,12 +20,12 @@ package com.kwai.koom.javaoom.monitor;
 public interface Threshold {
 
   /**
-   * @return value
+   * @return value 触发trigger的最低阀值，且必须命中策略heapOverTimes次才会真正触发
    */
   float value();
 
   /**
-   * @return maxValue
+   * @return maxValue 达到这个最大阀值，强制触发trigger
    */
   float maxValue();
 

--- a/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/Threshold.java
+++ b/java-oom/src/main/java/com/kwai/koom/javaoom/monitor/Threshold.java
@@ -25,6 +25,11 @@ public interface Threshold {
   float value();
 
   /**
+   * @return maxValue
+   */
+  float maxValue();
+
+  /**
    * @return threshold crossed times
    */
   int overTimes();


### PR DESCRIPTION
作者好，感谢作者大大的开源。发现一个小小的改进点，我试着将内存提升到90%多了，这时候GC比较频繁的，heapStatus.used >= lastHeapStatus.used条件不成立会导致策略命中次数清0。

而此时的内存已经很危险了，稍有不慎就会OOM然后应用直接Crash掉了，后面就没法触发trigger了，目前的策略对于这种情况无法处理。

我建议应该增加一种策略，大于85%小于95%用原来的策略，大于95%强制触发trigger。姑且将这个95%叫做最大阀值。这样可以覆盖更多的可能性情况。