### PR TITLE
Always static dependency libc++

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 GROUP=com.kuaishou.koom
-VERSION_NAME=2.2.0
+VERSION_NAME=2.2.1
 
 POM_URL=https://github.com/KwaiAppTeam/KOOM
 POM_SCM_URL=https://github.com/KwaiAppTeam/KOOM/tree/master

--- a/koom-native-leak/build.gradle
+++ b/koom-native-leak/build.gradle
@@ -55,7 +55,7 @@ android {
             ext.artifactIdSuffix = ''
             externalNativeBuild {
 		// Because koom-native-leak hook memory allocator, and hook implementation using some apis(may invoke memory allocator) from 
-		// libc++, then loop call lead stack overflow. so we always using "c++_static", and this increase package size,
+		// libc++, then infinite recursive call lead stack overflow. so we always using "c++_static", and this increase package size,
 		// you can dynamic delivery native-leak module using plugin technology
                 cmake {
                     arguments = ["-DANDROID_STL=c++_static"]

--- a/koom-native-leak/build.gradle
+++ b/koom-native-leak/build.gradle
@@ -54,8 +54,11 @@ android {
             dimension "stl_mode"
             ext.artifactIdSuffix = ''
             externalNativeBuild {
+		// Because koom-native-leak hook memory allocator, and hook implementation using some apis(may invoke memory allocator) from 
+		// libc++, then loop call lead stack overflow. so we always using "c++_static", and this increase package size,
+		// you can dynamic delivery native-leak module using plugin technology
                 cmake {
-                    arguments = ["-DANDROID_STL=c++_shared"]
+                    arguments = ["-DANDROID_STL=c++_static"]
                 }
             }
         }


### PR DESCRIPTION
## Background
- native leak module hook memory allocator(like: malloc/calloc/...)，and hook implementation also using some api (like: thread_local, invoke memory allocator) from libc++，then loop call lead stack overflow, see issue #194 
## Solution
- always static dependency libc++
- fix it in **KOOM v2.2.1**