### PR TITLE
update koom-native-leak/README

### DIFF
--- a/koom-native-leak/README.md
+++ b/koom-native-leak/README.md
@@ -60,7 +60,15 @@ LeakMonitor.INSTANCE.stop()
 ```java
 LeakMonitor.INSTANCE.checkLeaks()
 ```
-
+- **Attention**, please make sure that the config in `app/AndroidManifest.xml`, `android:extractNativeLibs` attribute must be `true`, otherwise LeakMonitor can not obtain any native leak record
+```xml
+...
+<application
+    ...
+    android:extractNativeLibs="true"
+    ...
+    />
+```
 # FAQ
 - Why are devices below Android N not supported?
     - AOSP added the libmemunreachable module after Android N, "Of course, you can also extract it by yourself and test it in the APP."

--- a/koom-native-leak/README.zh-CN.md
+++ b/koom-native-leak/README.zh-CN.md
@@ -53,6 +53,15 @@ LeakMonitor.INSTANCE.stop();
 ```java
 LeakMonitor.INSTANCE.checkLeaks();
 ```
+- **注意**，请确保`app/AndroidManifest.xml`中的配置，`android:extractNativeLibs`属性必须为`true`，否则无法抓取到native泄漏
+```xml
+...
+<application
+    ...
+    android:extractNativeLibs="true"
+    ...
+    />
+```
 # FAQ
 - 为什么不支持 Android N 以下的设备？
     - AOSP 在 Android N 之后系统才增加了 libmemunreachable 模块「当然也可以自己抽出来在 APP 测实现」


### PR DESCRIPTION
Indicate the importance of `android:extractNativeLibs`

使用NativeMonitor时，提醒用户`android:extractNativeLibs`需要设置为`true`（之前在群里提到过，抱歉比较晚才提交PR。）