### PR TITLE
feat:提高dump成功率

### DIFF
--- a/koom-fast-dump/src/main/cpp/hprof_dump.cpp
+++ b/koom-fast-dump/src/main/cpp/hprof_dump.cpp
@@ -144,7 +144,6 @@ bool HprofDump::ResumeAndWait(pid_t pid) {
       }
       return true;
     }
-    return false;
   }
 }
 

--- a/koom-fast-dump/src/main/cpp/hprof_dump.cpp
+++ b/koom-fast-dump/src/main/cpp/hprof_dump.cpp
@@ -136,7 +136,7 @@ bool HprofDump::ResumeAndWait(pid_t pid) {
   }
   int status;
   for (;;) {
-    if (waitpid(pid, &status, 0) != -1 || errno != EINTR) {
+    if (waitpid(pid, &status, 0) != -1) {
       if (!WIFEXITED(status)) {
         ALOGE("Child process %d exited with status %d, terminated by signal %d",
               pid, WEXITSTATUS(status), WTERMSIG(status));
@@ -144,6 +144,11 @@ bool HprofDump::ResumeAndWait(pid_t pid) {
       }
       return true;
     }
+    // 被信号中断调用的话，再发起一次waitpid调用即可
+    if (errno == EINTR){
+      continue;
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
当waitpid被信号中断时，errno == EINTR，可以直接发起下一次调用无需返回fasle，只需下次发器waitpid调用即可，提高dump成功率