### PR TITLE
Fix #260, Restore the origin value

### DIFF
--- a/koom-native-leak/src/main/jni/src/memory_analyzer.cpp
+++ b/koom-native-leak/src/main/jni/src/memory_analyzer.cpp
@@ -75,6 +75,8 @@ MemoryAnalyzer::CollectUnreachableMem() {
     return std::move(unreachable_mem);
   }
 
+  int origin_dumpable = prctl(PR_GET_DUMPABLE);
+
   // libmemunreachable NOT work in release apk because it using ptrace
   if (prctl(PR_SET_DUMPABLE, 1, 0, 0, 0) == -1) {
     ALOGE("Set process dumpable Fail");
@@ -85,7 +87,7 @@ MemoryAnalyzer::CollectUnreachableMem() {
   std::string unreachable_memory = get_unreachable_fn_(false, 1024);
 
   // Unset "dumpable" for security
-  prctl(PR_SET_DUMPABLE, 0, 0, 0, 0);
+  prctl(PR_SET_DUMPABLE, origin_dumpable, 0, 0, 0);
 
   std::regex filter_regex("[0-9]+ bytes unreachable at [A-Za-z0-9]+");
   std::sregex_iterator unreachable_begin(


### PR DESCRIPTION
恢复原有的dumpable值，解决Debug包中/proc/{pid}目录下文件、文件夹属主和属组被改为root的问题