### PR TITLE
fork dump support Android 12.1 - Android 14 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         'kotlin'           : '1.3.72',
         'kotlin_compiler'  : '1.4.21',
 
+        // TODO(wangzefeng): upgrade ndk version to support Android 14
         'ndk'           : '23.1.7779620',
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         'compileSdkVersion': 34,
         'buildToolsVersion': '31.0.0',
         'minSdkVersion'    : 18,
-        'targetSdkVersion' : 26,
+        'targetSdkVersion' : 30,
         'kotlin'           : '1.3.72',
         'kotlin_compiler'  : '1.4.21',
 

--- a/koom-monitor-base/src/main/java/com/kwai/koom/base/CommonConfig.kt
+++ b/koom-monitor-base/src/main/java/com/kwai/koom/base/CommonConfig.kt
@@ -78,6 +78,7 @@ class CommonConfig private constructor(
       mDebugMode = debugMode
     }
 
+    // NOTE(fork dump): fork dump check sdkVersionMatch first
     fun setSdkVersionMatch(sdkVersionMatch: Boolean) = apply {
       mSdkVersionMatch = sdkVersionMatch
     }

--- a/koom-monitor-base/src/main/java/com/kwai/koom/base/DefaultInitTask.kt
+++ b/koom-monitor-base/src/main/java/com/kwai/koom/base/DefaultInitTask.kt
@@ -27,8 +27,8 @@ object DefaultInitTask : InitTask {
       .setApplication(application) // Set application
       .setVersionNameInvoker { "1.0.0" } // Set version name, java leak feature use it
       .setSdkVersionMatch(
-        Build.VERSION.SDK_INT <= Build.VERSION_CODES.S && Build.VERSION.SDK_INT
-            >= Build.VERSION_CODES.LOLLIPOP
+        Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
       )  // Set if current sdk version is supported
       .build()
 


### PR DESCRIPTION
Just modify the android api version check logic, 
fork dump may cause a child process crash on Android 12, will be optimized in the next version. 